### PR TITLE
1 DRAFT. NOT FOR MERGE. The proposal for making filters in controllers via Maps

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11">
-      <module name="client-system.app-organization.test" target="1.8" />
-      <module name="client-system.app-party.test" target="1.8" />
-      <module name="client-system.app-product.test" target="1.8" />
-      <module name="client-system.app-user.test" target="1.8" />
-    </bytecodeTargetLevel>
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/app-product/src/main/kotlin/com/client/product/controller/ProductLinesController.kt
+++ b/app-product/src/main/kotlin/com/client/product/controller/ProductLinesController.kt
@@ -21,24 +21,24 @@ class ProductLinesController(service: ProductLinesService)
 
     override fun productLinesCreateProductLine(
 			@RequestBody productLine: ProductLine,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?): ResponseEntity<ProductLine> {
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?): ResponseEntity<ProductLine> {
         return super.create(productLine)
     }
 
     override fun productLinesDeleteProductLine(
 			@PathVariable("productLineId") productLineId: String,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?): ResponseEntity<ProductLine> {
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?): ResponseEntity<ProductLine> {
         return super.delete(productLineId)
     }
 
     override fun productLinesGetProductLine(
 			@PathVariable("productLineId") productLineId: String,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?): ResponseEntity<ProductLine> {
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?): ResponseEntity<ProductLine> {
         return super.getById(productLineId)
     }
 
     override fun productLinesGetProductLineList(
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?,
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?,
 			@RequestParam(value = "search", required = false) search: String?,
 			@PageableDefault(value=0, size = 50, sort=["id"], direction = Sort.Direction.ASC) page: Pageable): ResponseEntity<Page<ProductLine>> {
         return getAll(search, page)
@@ -47,14 +47,14 @@ class ProductLinesController(service: ProductLinesService)
     override fun productLinesModifyProductLine(
 			@PathVariable("productLineId") productLineId: String,
 			@RequestBody productLine: ProductLine,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?): ResponseEntity<ProductLine> {
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?): ResponseEntity<ProductLine> {
         return super.modify(productLineId, productLine)
     }
 
     override fun productLinesUpdateProductLine(
 			@PathVariable("productLineId") productLineId: String,
 			@RequestBody productLine: ProductLine,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?): ResponseEntity<ProductLine> {
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?): ResponseEntity<ProductLine> {
         return super.update(productLineId, productLine)
     }
 

--- a/app-product/src/main/kotlin/com/client/product/controller/ProductsController.kt
+++ b/app-product/src/main/kotlin/com/client/product/controller/ProductsController.kt
@@ -34,24 +34,24 @@ class ProductsController(service: ProductsService)
     override fun productsGetProduct(
 			@PathVariable("productLineId") productLineId: String,
 			@PathVariable("productId") productId: String,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?,
-			@ApiParam(value = "for filtering as a sample of Enum" ) @RequestHeader(value="type", required=false) type: String?,
-			@ApiParam(value = "for filtering as a sample of boolean" ) @RequestHeader(value="critical", required=false) critical: Boolean?,
-			@ApiParam(value = "for filtering as a sample of Integer" ) @RequestHeader(value="rank", required=false) rank: Integer?,
-			@ApiParam(value = "for filtering as a sample of String" ) @RequestHeader(value="estimation", required=false) estimation: String?): ResponseEntity<Product> {
-        return super.getById(productLineId, productId)
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?,
+			@ApiParam(value = "for filtering as a sample of Enum" ) @RequestHeader(value = "type", required = false) type: String?,
+			@ApiParam(value = "for filtering as a sample of boolean" ) @RequestHeader(value = "critical", required = false) critical: Boolean?,
+			@ApiParam(value = "for filtering as a sample of Integer" ) @RequestHeader(value = "rank", required = false) rank: Int?,
+			@ApiParam(value = "for filtering as a sample of String" ) @RequestHeader(value = "estimation", required = false) estimation: String?): ResponseEntity<Product> {
+        return super.getById(productLineId, productId, mapOf("partyId" to partyId, "type" to type, "critical" to critical, "rank" to rank, "estimation" to estimation))
     }
 
     override fun productsGetProductList(
 			@PathVariable("productLineId") productLineId: String,
 			@RequestParam(value = "search", required = false) search: String?,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?,
-			@ApiParam(value = "for filtering as a sample of Enum" ) @RequestHeader(value="type", required=false) type: String?,
-			@ApiParam(value = "for filtering as a sample of boolean" ) @RequestHeader(value="critical", required=false) critical: Boolean?,
-			@ApiParam(value = "for filtering as a sample of Integer" ) @RequestHeader(value="rank", required=false) rank: Integer?,
-			@ApiParam(value = "for filtering as a sample of String" ) @RequestHeader(value="estimation", required=false) estimation: String?,
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?,
+			@ApiParam(value = "for filtering as a sample of Enum" ) @RequestHeader(value = "type", required = false) type: String?,
+			@ApiParam(value = "for filtering as a sample of boolean" ) @RequestHeader(value = "critical", required = false) critical: Boolean?,
+			@ApiParam(value = "for filtering as a sample of Integer" ) @RequestHeader(value = "rank", required = false) rank: Int?,
+			@ApiParam(value = "for filtering as a sample of String" ) @RequestHeader(value = "estimation", required = false) estimation: String?,
 			@PageableDefault(value=0, size = 50, sort=["id"], direction = Sort.Direction.ASC) page: Pageable): ResponseEntity<Page<Product>> {
-        return getAll(productLineId, search, page)
+        return getAll(productLineId, search, page, mapOf("partyId" to partyId, "type" to type, "critical" to critical, "rank" to rank, "estimation" to estimation))
     }
 
     override fun productsModifyProduct(

--- a/app-product/src/main/kotlin/com/client/product/controller/api/ProductLinesApi.kt
+++ b/app-product/src/main/kotlin/com/client/product/controller/api/ProductLinesApi.kt
@@ -28,7 +28,7 @@ interface ProductLinesApi {
     @PostMapping("/parties/{partyId}/productlines")
     fun productLinesCreateProductLine(
 			@RequestBody productLine: ProductLine,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?): ResponseEntity<ProductLine> {
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?): ResponseEntity<ProductLine> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
     }
 
@@ -41,7 +41,7 @@ interface ProductLinesApi {
     @DeleteMapping("/parties/{partyId}/productlines/{productLineId}")
     fun productLinesDeleteProductLine(
 			@PathVariable("productLineId") productLineId: String,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?): ResponseEntity<ProductLine> {
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?): ResponseEntity<ProductLine> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
     }
 
@@ -54,7 +54,7 @@ interface ProductLinesApi {
     @GetMapping("/parties/{partyId}/productlines/{productLineId}")
     fun productLinesGetProductLine(
 			@PathVariable("productLineId") productLineId: String,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?): ResponseEntity<ProductLine> {
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?): ResponseEntity<ProductLine> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
     }
 
@@ -66,7 +66,7 @@ interface ProductLinesApi {
     )
     @GetMapping("/parties/{partyId}/productlines")
     fun productLinesGetProductLineList(
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?,
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?,
 			@RequestParam(value = "search", required = false) search: String?,
 			@PageableDefault(value=0, size = 50, sort=["id"], direction = Sort.Direction.ASC) page: Pageable): ResponseEntity<Page<ProductLine>> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
@@ -82,7 +82,7 @@ interface ProductLinesApi {
     fun productLinesModifyProductLine(
 			@PathVariable("productLineId") productLineId: String,
 			@RequestBody productLine: ProductLine,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?): ResponseEntity<ProductLine> {
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?): ResponseEntity<ProductLine> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
     }
 
@@ -96,7 +96,7 @@ interface ProductLinesApi {
     fun productLinesUpdateProductLine(
 			@PathVariable("productLineId") productLineId: String,
 			@RequestBody productLine: ProductLine,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?): ResponseEntity<ProductLine> {
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?): ResponseEntity<ProductLine> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
     }
 

--- a/app-product/src/main/kotlin/com/client/product/controller/api/ProductsApi.kt
+++ b/app-product/src/main/kotlin/com/client/product/controller/api/ProductsApi.kt
@@ -55,11 +55,11 @@ interface ProductsApi {
     fun productsGetProduct(
 			@PathVariable("productLineId") productLineId: String,
 			@PathVariable("productId") productId: String,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?,
-			@ApiParam(value = "for filtering as a sample of Enum" ) @RequestHeader(value="type", required=false) type: String?,
-			@ApiParam(value = "for filtering as a sample of boolean" ) @RequestHeader(value="critical", required=false) critical: Boolean?,
-			@ApiParam(value = "for filtering as a sample of Integer" ) @RequestHeader(value="rank", required=false) rank: Integer?,
-			@ApiParam(value = "for filtering as a sample of String" ) @RequestHeader(value="estimation", required=false) estimation: String?): ResponseEntity<Product> {
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?,
+			@ApiParam(value = "for filtering as a sample of Enum" ) @RequestHeader(value = "type", required = false) type: String?,
+			@ApiParam(value = "for filtering as a sample of boolean" ) @RequestHeader(value = "critical", required = false) critical: Boolean?,
+			@ApiParam(value = "for filtering as a sample of Integer" ) @RequestHeader(value = "rank", required = false) rank: Int?,
+			@ApiParam(value = "for filtering as a sample of String" ) @RequestHeader(value = "estimation", required = false) estimation: String?): ResponseEntity<Product> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
     }
 
@@ -73,11 +73,11 @@ interface ProductsApi {
     fun productsGetProductList(
 			@PathVariable("productLineId") productLineId: String,
 			@RequestParam(value = "search", required = false) search: String?,
-			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value="partyId", required=false) partyId: String?,
-			@ApiParam(value = "for filtering as a sample of Enum" ) @RequestHeader(value="type", required=false) type: String?,
-			@ApiParam(value = "for filtering as a sample of boolean" ) @RequestHeader(value="critical", required=false) critical: Boolean?,
-			@ApiParam(value = "for filtering as a sample of Integer" ) @RequestHeader(value="rank", required=false) rank: Integer?,
-			@ApiParam(value = "for filtering as a sample of String" ) @RequestHeader(value="estimation", required=false) estimation: String?,
+			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?,
+			@ApiParam(value = "for filtering as a sample of Enum" ) @RequestHeader(value = "type", required = false) type: String?,
+			@ApiParam(value = "for filtering as a sample of boolean" ) @RequestHeader(value = "critical", required = false) critical: Boolean?,
+			@ApiParam(value = "for filtering as a sample of Integer" ) @RequestHeader(value = "rank", required = false) rank: Int?,
+			@ApiParam(value = "for filtering as a sample of String" ) @RequestHeader(value = "estimation", required = false) estimation: String?,
 			@PageableDefault(value=0, size = 50, sort=["id"], direction = Sort.Direction.ASC) page: Pageable): ResponseEntity<Page<Product>> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
     }

--- a/common/src/main/kotlin/com/client/controller/AbstractController.kt
+++ b/common/src/main/kotlin/com/client/controller/AbstractController.kt
@@ -26,13 +26,37 @@ abstract class AbstractController<E: BaseResource, S: CommonService<E>>(val  ser
 		return ResponseEntity(entity, HttpStatus.OK)
 	}
 
+	override fun delete(id: String, filter: Map<String, Any?>): ResponseEntity<E> {
+		val filterQuery = getFilterQuery(filter)
+		if (filterQuery.isEmpty()) {
+			return delete(id)
+		}
+		val entity = service.getByIdAndFilter(id, filterQuery) ?: throw ResourceNotFoundException()
+		service.delete(entity)
+		return ResponseEntity(entity, HttpStatus.OK)
+	}
+
 	override fun getById(id: String): ResponseEntity<E> {
 		val entity = service.getById(id)?: throw ResourceNotFoundException()
 		return ResponseEntity(entity, HttpStatus.OK)
 	}
 
+	override fun getById(id: String, filter: Map<String, Any?>): ResponseEntity<E> {
+		val filterQuery = getFilterQuery(filter)
+		if (filterQuery.isEmpty()) {
+			return getById(id)
+		}
+		val entity = service.getByIdAndFilter(id, filterQuery) ?: throw ResourceNotFoundException()
+		return ResponseEntity(entity, HttpStatus.OK)
+	}
+
 	override fun getAll(search: String?, pageable : Pageable): ResponseEntity<Page<E>> {
 		return ResponseEntity(service.getAll(pageable, search), HttpStatus.OK)
+	}
+
+	override fun getAll(search: String?, pageable : Pageable, filter: Map<String, Any?>): ResponseEntity<Page<E>> {
+		val searchCriteria = getSearchCriteria(search, filter)
+		return ResponseEntity(service.getAll(pageable, searchCriteria), HttpStatus.OK)
 	}
 
 	override fun update(id: String, domain: E): ResponseEntity<E> {
@@ -42,7 +66,21 @@ abstract class AbstractController<E: BaseResource, S: CommonService<E>>(val  ser
 		return ResponseEntity(result, HttpStatus.OK)
 	}
 
+	override fun update(id: String, domain: E, filter: Map<String, Any?>): ResponseEntity<E> {
+		val filterQuery = getFilterQuery(filter)
+		if (!filterQuery.isEmpty()) {
+			service.getByIdAndFilter(id, filterQuery) ?: throw ResourceNotFoundException()
+		}
+		domain.id = id
+		val result = service.update(domain)?: throw InvalidRequestException()
+		return ResponseEntity(result, HttpStatus.OK)
+	}
+
 	override fun modify(id: String, domain: E): ResponseEntity<E> {
+		return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+	}
+
+	override fun modify(id: String, domain: E, filter: Map<String, Any?>): ResponseEntity<E> {
 		return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 	}
 
@@ -50,8 +88,32 @@ abstract class AbstractController<E: BaseResource, S: CommonService<E>>(val  ser
 		return service.saveAll(domains)
 	}
 
+	override fun saveAll(domains: List<E>, filter: Map<String, Any?>): List<E> {
+		val filterQuery = getFilterQuery(filter)
+		if (!filterQuery.isEmpty()) {
+			domains.forEach {
+				val id = it.id ?: throw ResourceNotFoundException()
+				service.getByIdAndFilter(id, filterQuery) ?: throw ResourceNotFoundException()
+			}
+		}
+		return service.saveAll(domains)
+	}
+
 	override fun deleteAll(@RequestParam ids: List<String>): List<E> {
 		val domains = service.getByIds(ids)
+		service.deleteAll(domains)
+		return domains
+	}
+
+	override fun deleteAll(@RequestParam ids: List<String>, filter: Map<String, Any?>): List<E> {
+		val domains = service.getByIds(ids)
+		val filterQuery = getFilterQuery(filter)
+		if (!filterQuery.isEmpty()) {
+			domains.forEach{
+				val id = it.id ?: throw ResourceNotFoundException()
+				service.getByIdAndFilter(id, filterQuery) ?: throw ResourceNotFoundException()
+			}
+		}
 		service.deleteAll(domains)
 		return domains
 	}
@@ -72,8 +134,29 @@ abstract class AbstractController<E: BaseResource, S: CommonService<E>>(val  ser
 		return ResponseEntity(domain, HttpStatus.OK)
 	}
 
+	override fun getById(parentId: String, id: String, filter: Map<String, Any?>): ResponseEntity<E> {
+		val filterQuery = getFilterQuery(filter)
+		if (filterQuery.isEmpty()) {
+			return getById(parentId, id)
+		}
+		val domain = service.getByIdAndFilter(id, filterQuery) ?: throw ResourceNotFoundException()
+		Assert.isTrue(parentId == domain.entity.parent?.id, "parent $parentId is not valid")
+		return ResponseEntity(domain, HttpStatus.OK)
+	}
+
 	override fun delete(parentId: String, id: String): ResponseEntity<E> {
 		val domain = service.getById(id) ?: throw ResourceNotFoundException()
+		validateParent(domain, parentId)
+		service.delete(domain)
+		return ResponseEntity(domain, HttpStatus.OK)
+	}
+
+	override fun delete(parentId: String, id: String, filter: Map<String, Any?>): ResponseEntity<E> {
+		val filterQuery = getFilterQuery(filter)
+		if (filterQuery.isEmpty()) {
+			return delete(parentId, id)
+		}
+		val domain = service.getByIdAndFilter(id, filterQuery) ?: throw ResourceNotFoundException()
 		validateParent(domain, parentId)
 		service.delete(domain)
 		return ResponseEntity(domain, HttpStatus.OK)
@@ -86,12 +169,41 @@ abstract class AbstractController<E: BaseResource, S: CommonService<E>>(val  ser
 		return ResponseEntity(updatedEntity, HttpStatus.OK)
 	}
 
+	override fun update(parentId: String, id: String, domain: E, filter: Map<String, Any?>): ResponseEntity<E> {
+		val filterQuery = getFilterQuery(filter)
+		if (!filterQuery.isEmpty()) {
+			service.getByIdAndFilter(id, filterQuery) ?: throw ResourceNotFoundException()
+		}
+		validateParent(domain, parentId)
+		domain.id = id
+		val updatedEntity = service.update(domain)
+		return ResponseEntity(updatedEntity, HttpStatus.OK)
+	}
+
 	override fun modify(parentId: String, id: String, domain: E): ResponseEntity<E> {
+		return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+	}
+
+	override fun modify(parentId: String, id: String, domain: E, filter: Map<String, Any?>): ResponseEntity<E> {
 		return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 	}
 
 	override fun saveAll(parentId: String, domains: List<E>): List<E> {
 		domains.forEach {
+			validateParent(it, parentId)
+			it.id = it.identity.id
+		}
+		return service.saveAll(domains)
+	}
+
+	override fun saveAll(parentId: String, domains: List<E>, filter: Map<String, Any?>): List<E> {
+		val filterQuery = getFilterQuery(filter)
+		if (filterQuery.isEmpty()) {
+			return saveAll(parentId, domains)
+		}
+		domains.forEach {
+			val id = it.id ?: throw ResourceNotFoundException()
+			service.getByIdAndFilter(id, filterQuery) ?: throw ResourceNotFoundException()
 			validateParent(it, parentId)
 			it.id = it.identity.id
 		}
@@ -107,9 +219,28 @@ abstract class AbstractController<E: BaseResource, S: CommonService<E>>(val  ser
 		return entities
 	}
 
+	override fun deleteAll(parentId: String, ids: List<String>, filter: Map<String, Any?>): List<E> {
+		val entities = service.getByIds(ids)
+		val filterQuery = getFilterQuery(filter)
+		if (filterQuery.isEmpty()) {
+			return deleteAll(parentId, ids)
+		}
+		entities.forEach {
+			val id = it.id ?: throw ResourceNotFoundException()
+			service.getByIdAndFilter(id, filterQuery) ?: throw ResourceNotFoundException()
+			validateParent(it, parentId)
+		}
+		service.deleteAll(entities)
+		return entities
+	}
+
 	override fun getAll(parentId: String, search: String?, pageable: Pageable): ResponseEntity<Page<E>> {
 		val searchCriteria = getSearchCriteria(search, parentId)
+		return ResponseEntity(service.getAll(pageable, searchCriteria), HttpStatus.OK)
+	}
 
+	override fun getAll(parentId: String, search: String?, pageable: Pageable, filter: Map<String, Any?>): ResponseEntity<Page<E>> {
+		val searchCriteria = getSearchCriteria(search, parentId, filter)
 		return ResponseEntity(service.getAll(pageable, searchCriteria), HttpStatus.OK)
 	}
 
@@ -126,5 +257,40 @@ abstract class AbstractController<E: BaseResource, S: CommonService<E>>(val  ser
 		} else {
 			"$underParentSearchCriteria;$query"
 		}
+	}
+
+	private fun getSearchCriteria(query: String?, filter: Map<String, Any?>): String? {
+		val filterQuery = getFilterQuery(filter)
+		return if (filterQuery.isEmpty()) {
+			if (query.isNullOrBlank()) {
+				null
+			} else {
+				query
+			}
+		} else if (query.isNullOrBlank()) {
+			filterQuery
+		} else {
+			"$filterQuery;$query"
+		}
+	}
+
+	private fun getSearchCriteria(query: String?, parentId: String, filter: Map<String, Any?>): String {
+		val baseSearchCriteria = getSearchCriteria(query, filter)
+		val underParentSearchCriteria = "entity.parent.id==$parentId"
+		return if (baseSearchCriteria.isNullOrBlank()) {
+			underParentSearchCriteria
+		} else {
+			"$underParentSearchCriteria;$baseSearchCriteria"
+		}
+	}
+
+	private fun getFilterQuery(filter: Map<String, Any?>): String {
+		var result = ""
+		filter.forEach { (key, value) ->
+			if (key != null && value != null) {
+				result = "$result;$key==$value"
+			}
+		}
+		return result
 	}
 }

--- a/common/src/main/kotlin/com/client/controller/CommonController.kt
+++ b/common/src/main/kotlin/com/client/controller/CommonController.kt
@@ -14,4 +14,12 @@ interface CommonController<E : BaseResource> {
     fun modify(id: String, domain: E): ResponseEntity<E>
     fun saveAll(domains: List<E>): List<E>
     fun deleteAll(ids: List<String>): List<E>
+
+	fun delete(id: String, filter: Map<String, Any?>): ResponseEntity<E>
+    fun getById(id: String, filter: Map<String, Any?>): ResponseEntity<E>
+    fun getAll(search: String?, pageable: Pageable, filter: Map<String, Any?>): ResponseEntity<Page<E>>
+    fun update(id: String, domain: E, filter: Map<String, Any?>): ResponseEntity<E>
+    fun modify(id: String, domain: E, filter: Map<String, Any?>): ResponseEntity<E>
+    fun saveAll(domains: List<E>, filter: Map<String, Any?>): List<E>
+    fun deleteAll(ids: List<String>, filter: Map<String, Any?>): List<E>
 }

--- a/common/src/main/kotlin/com/client/controller/CommonParameterizedController.kt
+++ b/common/src/main/kotlin/com/client/controller/CommonParameterizedController.kt
@@ -14,4 +14,12 @@ interface CommonParameterizedController<E : BaseResource> {
     fun saveAll(parentId: String, domains: List<E>): List<E>
     fun deleteAll(parentId: String, ids: List<String>): List<E>
     fun getAll(parentId: String, search: String?, pageable : Pageable): ResponseEntity<Page<E>>
+
+	fun getById(parentId: String, id: String, filter: Map<String, Any?>): ResponseEntity<E>
+    fun delete(parentId: String, id: String, filter: Map<String, Any?>): ResponseEntity<E>
+    fun update(parentId: String, id: String, domain: E, filter: Map<String, Any?>): ResponseEntity<E>
+    fun modify(parentId: String, id: String, domain: E, filter: Map<String, Any?>): ResponseEntity<E>
+    fun saveAll(parentId: String, domains: List<E>, filter: Map<String, Any?>): List<E>
+    fun deleteAll(parentId: String, ids: List<String>, filter: Map<String, Any?>): List<E>
+    fun getAll(parentId: String, search: String?, pageable : Pageable, filter: Map<String, Any?>): ResponseEntity<Page<E>>
 }

--- a/common/src/main/kotlin/com/client/service/AbstractService.kt
+++ b/common/src/main/kotlin/com/client/service/AbstractService.kt
@@ -71,4 +71,10 @@ abstract class AbstractService<E: BaseResource, R: CommonRepository<E>>(protecte
 		val spec: Specification<E> = rootNode.accept(JpaRsqlVisitor())
 		return repository.findAll(spec, pageable)
 	}
+
+	override fun getByIdAndFilter(id: String, filter: String): E? {
+		val rootNode: Node = RsqlParserFactory.instance().parse("id==$id;(entity.state=isNull=true,entity.state!=deleted);$filter")
+		val spec: Specification<E> = rootNode.accept(JpaRsqlVisitor())
+		return repository.findOne(spec).orElse(null)
+	}
 }

--- a/common/src/main/kotlin/com/client/service/CommonService.kt
+++ b/common/src/main/kotlin/com/client/service/CommonService.kt
@@ -14,4 +14,5 @@ interface CommonService<E: BaseResource> {
 	fun getAll(pageable: Pageable, query: String?): Page<E>
 	fun getByIds(ids: List<String>): List<E>
 	fun deleteAll(domains: List<E>)
+	fun getByIdAndFilter(id: String, filter: String): E?
 }


### PR DESCRIPTION
The proposal is  - let use Map to collect filter params for passing them from controller instance to the AbstructController.
Then these filter params are used to form the query for RSQL.
```
override fun productsGetProductList(
			@PathVariable("productLineId") productLineId: String,
			@RequestParam(value = "search", required = false) search: String?,
			@ApiParam(value = "for filtering as a sample of Guid" ) @RequestHeader(value = "partyId", required = false) partyId: String?,
			@ApiParam(value = "for filtering as a sample of Enum" ) @RequestHeader(value = "type", required = false) type: String?,
			@ApiParam(value = "for filtering as a sample of boolean" ) @RequestHeader(value = "critical", required = false) critical: Boolean?,
			@ApiParam(value = "for filtering as a sample of Integer" ) @RequestHeader(value = "rank", required = false) rank: Int?,
			@ApiParam(value = "for filtering as a sample of String" ) @RequestHeader(value = "estimation", required = false) estimation: String?,
			@PageableDefault(value=0, size = 50, sort=["id"], direction = Sort.Direction.ASC) page: Pageable): ResponseEntity<Page<Product>> {
        return getAll(productLineId, search, page, mapOf("partyId" to partyId, "type" to type, "critical" to critical, "rank" to rank, "estimation" to estimation))
    }
```

The logic of using filters in AbstractService and AbstractConnector is draft and should be redesigned for be much more efficiency



Also the param's type Integer fixed to Int. Made code convential changes
